### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nestjs-ajv-glue",
   "version": "1.0.1",
   "description": "AJV OpenAPI glue for NestJS",
-  "main": "index.js",
+  "main": "dist/index.js",
   "author": "Mateusz Perlak",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
When I try to import `nestjs-ajv-glue`, I get the following error: `Cannot find module 'nestjs-ajv-glue' or its corresponding type declarations.` This PR fixes the issue by changing the `main` property in `package.json` from `index.js` to `dist/index.js` As a workaround, I used `import { AjvValidationPipe } from 'nestjs-ajv-glue/dist/index';`.